### PR TITLE
refactor: download process to use worker pool to fetch page concurrently

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"regexp"
@@ -13,6 +12,7 @@ import (
 	"github.com/caarlos0/env"
 	"github.com/joho/godotenv"
 	pdf "github.com/loxiouve/unipdf/v3/model"
+	"github.com/sirupsen/logrus"
 )
 
 type EnvSchema struct {
@@ -20,13 +20,25 @@ type EnvSchema struct {
 	START_PAGE int    `env:"START_PAGE"`
 }
 
-var environment EnvSchema
+var (
+	environment EnvSchema
+	log         = logrus.New()
+)
+
+func init() {
+	log.Formatter = &logrus.TextFormatter{FullTimestamp: true}
+	log.Level = logrus.InfoLevel
+}
 
 func loadEnv() {
-	err := godotenv.Load(`.env`)
-	_ = env.Parse(&environment)
+	err := godotenv.Load(".env")
 	if err != nil {
-		log.Fatalf("Error loading .env file")
+		log.WithError(err).Fatal("Failed to load .env file")
+	}
+
+	err = env.Parse(&environment)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to parse environment variables")
 	}
 }
 
@@ -35,32 +47,42 @@ const PAGE_URI_PATTERN = "https://learn.eltngl.com/cdn_proxy/%s/media/%s"
 
 func findPageFileNames() ([]string, error) {
 	dataUri := fmt.Sprintf(DATA_URI_PATTERN, environment.BOOK_ID)
+	log.WithField("url", dataUri).Info("Fetching data")
+
 	response, err := http.Get(dataUri)
 	if err != nil {
-		log.Fatalln(err)
-	}
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
+		log.WithError(err).Error("Failed to fetch data")
 		return nil, err
 	}
-	bodyString := string(body)
-	pdfPattern := regexp.MustCompile(`page-([0-9a-z]*)\.pdf`)
-	matches := pdfPattern.FindAllString(bodyString, -1)
-	return matches, nil
-}
-
-func fetchPage(pageUri string) (*pdf.PdfPage, error) {
-	response, err := http.Get(pageUri)
-	if err != nil {
-		fmt.Println("response")
-		return nil, err
-	}
-
 	defer response.Body.Close()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		fmt.Println("body")
+		log.WithError(err).Error("Failed to read data")
+		return nil, err
+	}
+
+	bodyString := string(body)
+	pdfPattern := regexp.MustCompile(`page-([0-9a-z]*)\.pdf`)
+	matches := pdfPattern.FindAllString(bodyString, -1)
+
+	log.WithField("page_count", len(matches)).Info("Found page file names")
+	return matches, nil
+}
+
+func fetchPage(pageUri string) (*pdf.PdfPage, error) {
+	log.WithField("url", pageUri).Info("Fetching page")
+
+	response, err := http.Get(pageUri)
+	if err != nil {
+		log.WithError(err).Error("Failed to fetch page")
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.WithError(err).Error("Failed to read page")
 		return nil, err
 	}
 
@@ -69,15 +91,30 @@ func fetchPage(pageUri string) (*pdf.PdfPage, error) {
 
 	currentPdf, err := pdf.NewPdfReader(bodyBytes)
 	if err != nil {
-		fmt.Println("currentPdf")
+		log.WithError(err).Error("Failed to read PDF")
 		return nil, err
 	}
 
 	page, err := currentPdf.GetPage(1)
 	if err != nil {
+		log.WithError(err).Error("Failed to get page from PDF")
 		return nil, err
 	}
+
+	log.WithField("page_number", currentPdf.GetNumPages).Info("Successfully fetched page")
 	return page, nil
+}
+
+func worker(jobs <-chan string, results chan<- *pdf.PdfPage, errors chan<- error, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for pageUri := range jobs {
+		page, err := fetchPage(pageUri)
+		if err != nil {
+			errors <- err
+			continue
+		}
+		results <- page
+	}
 }
 
 func download() error {
@@ -85,43 +122,68 @@ func download() error {
 	if err != nil {
 		return err
 	}
+
+	numWorkers := 10
 	pdfWriter := pdf.NewPdfWriter()
-	pagesList := make([]*pdf.PdfPage, len(pageFileNames)-environment.START_PAGE)
+
+	jobs := make(chan string, len(pageFileNames)-environment.START_PAGE)
+	results := make(chan *pdf.PdfPage, len(pageFileNames)-environment.START_PAGE)
+	errors := make(chan error, len(pageFileNames)-environment.START_PAGE)
+
 	var wg sync.WaitGroup
-	for index, pageFilename := range pageFileNames[environment.START_PAGE:] {
-		pageUri := fmt.Sprintf(PAGE_URI_PATTERN, environment.BOOK_ID, pageFilename)
 
+	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
-		go func(index int, pageUri string) error {
-			page, err := fetchPage(pageUri)
-			if err != nil {
-				return err
-			}
-			pagesList[index] = page
-			wg.Done()
-			return nil
-		}(index, pageUri)
+		go func() {
+			worker((<-chan string)(jobs), chan<- *pdf.PdfPage(results), chan<- error(errors), &wg)
+		}()
 	}
 
-	wg.Wait()
+	// Enqueue jobs
+	for _, pageFilename := range pageFileNames[environment.START_PAGE:] {
+		pageUri := fmt.Sprintf(PAGE_URI_PATTERN, environment.BOOK_ID, pageFilename)
+		jobs <- pageUri
+	}
+	close(jobs)
 
-	for _, page := range pagesList {
-		pdfWriter.AddPage(page)
+	// Wait for workers to finish
+	go func() {
+		wg.Wait()
+		close(results)
+		close(errors)
+	}()
+
+	for i := 0; i < len(pageFileNames)-environment.START_PAGE; i++ {
+		select {
+		case err := <-errors:
+			log.WithError(err).Error("Error while fetching pages")
+		case page := <-results:
+			pdfWriter.AddPage(page)
+		}
 	}
 
+	log.Info("Writing pages to PDF")
 	err = os.MkdirAll("output", os.ModePerm)
 	if err != nil {
+		log.WithError(err).Error("Failed to create output directory")
 		return err
 	}
-	outputIO, err := os.Create("output/downloaded.pdf")
+
+	outputFilePath := "output/downloaded.pdf"
+	outputIO, err := os.Create(outputFilePath)
 	if err != nil {
+		log.WithError(err).Error("Failed to create output file")
 		return err
 	}
 	defer outputIO.Close()
+
 	err = pdfWriter.Write(outputIO)
 	if err != nil {
+		log.WithError(err).Error("Failed to write PDF")
 		return err
 	}
+
+	log.WithField("file", outputFilePath).Info("Successfully downloaded PDF")
 	return nil
 }
 
@@ -129,6 +191,6 @@ func main() {
 	loadEnv()
 	err := download()
 	if err != nil {
-		fmt.Println("error: ", err)
+		log.WithError(err).Fatal("Download process failed")
 	}
 }


### PR DESCRIPTION
- for me it takes forever to download an entire book
## Description
- Introduced a worker pool pattern to fetch pages concurrently
- improved logging a little bit

## Before
- it takes like 10 min to scrape now and I dont see any progress
<img width="511" alt="Screenshot 2567-08-24 at 15 19 31" src="https://github.com/user-attachments/assets/3df18278-6a6a-4551-91b0-9e9913f0ee7d">

## After 
- i downloaded the entire book in 3.54 mins
<img width="436" alt="Screenshot 2567-08-24 at 15 11 11" src="https://github.com/user-attachments/assets/a42cc612-a5e4-4ddd-859b-d4a856163b67">

I dont know if this have a downside please review kub @NewBieCoderXD 
